### PR TITLE
Add .zshrc for jsh --osc emulation

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,20 @@
+# Load zsh-hook
+autoload -Uz add-zsh-hook
+
+# send osc 654
+send_osc654() {
+  echo -ne "\033]654;$1\007"
+}
+
+# after command, before prompt
+precmd_function() {
+  local EXIT_CODE=$?
+  send_osc654 "exit=$EXIT_CODE:0"
+  send_osc654 "prompt"
+}
+
+# register hook
+add-zsh-hook precmd precmd_function
+
+# send initial message
+send_osc654 "interactive"

--- a/Containerfile
+++ b/Containerfile
@@ -11,7 +11,7 @@ RUN bun run build
 FROM oven/bun:1.2.10-slim
 
 # install zsh
-RUN apt-get update && apt-get install -y zsh bsdutils && apt-get clean
+RUN apt-get update && apt-get install -y zsh && apt-get clean
 
 # copy .zshrc
 COPY .zshrc /root/.zshrc

--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,12 @@ RUN bun run build
 
 FROM oven/bun:1.2.10-slim
 
+# install zsh
+RUN apt-get update && apt-get install -y zsh bsdutils && apt-get clean
+
+# copy .zshrc
+COPY .zshrc /root/.zshrc
+
 WORKDIR /app
 
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
This PR adds zsh environment and `.zshrc` to built container image, to emulate `jsh --osc` behavior.