### PR TITLE
Introduce GET `/api/machine/:id` API 

### DIFF
--- a/src/fly/client.ts
+++ b/src/fly/client.ts
@@ -110,4 +110,33 @@ export class FlyClient {
   async getImageRef(): Promise<string | undefined> {
     return this.config.imageRef;
   }
-} 
+
+  /**
+   * Get real-time machine status from Fly API.
+   * @param machineId - The ID of the machine to check
+   * @returns Machine details and current status or null if not found
+   */
+  async getMachineStatus(machineId: string): Promise<Machine | null> {
+    try {
+      const res = await fetch(`${this.config.baseUrl}/apps/${this.config.appName}/machines/${machineId}`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this.config.apiToken}`,
+          Accept: "application/json",
+        },
+      });
+
+      if (!res.ok) {
+        if (res.status === 404) {
+          return null;
+        }
+        throw new Error(`HTTP ${res.status} - ${res.statusText}`);
+      }
+
+      return await res.json() as Machine;
+    } catch (e: unknown) {
+      console.error("Fly API error:", e instanceof Error ? e.message : e);
+      throw e;
+    }
+  }
+}

--- a/src/fly/client.ts
+++ b/src/fly/client.ts
@@ -1,4 +1,4 @@
-import { FlyConfig, Machine, MachineMap, CreateMachineOptions } from './types';
+import { FlyConfig, Machine, CreateMachineOptions } from './types';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();

--- a/src/server.ts
+++ b/src/server.ts
@@ -234,7 +234,7 @@ export class ContainerServer {
           }
           const isPreview = rest[0] === "preview";
           const targetUrl = isPreview
-            ? `http://[${ip}]:5174/${rest.slice(1).join("/")}`
+            ? `http://[${ip}]:${httpPort}/${rest.slice(1).join("/")}`
             : `ws://[${ip}]:3000/${rest.join("/")}`;
 
           if (server.upgrade(req, { data: { targetUrl } })) {


### PR DESCRIPTION
As subject said, this PR adds `/api/machine/:id` endpoint to determine machine ready state via HTTP.