### PR TITLE
Remove remote proxy and add local proxy

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,14 +11,11 @@ function main() {
     workdirName: process.env.WORKDIR_NAME || "/workspace",
     coep: process.env.COEP || "credentialless",
     forwardPreviewErrors: process.env.FORWARD_PREVIEW_ERRORS === "true",
-    appHostName: process.env.APP_HOST_NAME || "localhost",
+    routerDomain: process.env.FLY_ROUTER_DOMAIN || "agent8.verse8.net",
+    appName: process.env.FLY_APP_NAME || "",
     machineId: process.env.FLY_MACHINE_ID || "",
     processGroup: process.env.FLY_PROCESS_GROUP || "app",
   };
-
-  if (process.env.FLY_APP_NAME) {
-    config.appHostName = `${process.env.FLY_APP_NAME}.fly.dev`;
-  }
 
   const server = new ContainerServer(config);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,12 +86,14 @@ export class ContainerServer {
     workdirName: string;
     coep: string;
     forwardPreviewErrors: boolean;
-    appHostName: string;
+    routerDomain: string;
+    appName: string;
     machineId: string;
     processGroup: string;
   };
   private authToken: string | undefined;
-  private appHostName: string;
+  private routerDomain: string;
+  private appName: string;
   private machineId: string;
   private flyClientPromise: Promise<FlyClient>;
   private readonly authManager: AuthManager;
@@ -106,7 +108,8 @@ export class ContainerServer {
     workdirName: string;
     coep: string;
     forwardPreviewErrors: boolean;
-    appHostName: string;
+    routerDomain: string;
+    appName: string;
     machineId: string;
     processGroup: string;
   }) {
@@ -118,7 +121,8 @@ export class ContainerServer {
     this.processClients = new Map();
     this.clientWatchers = new Map();
     this.connectionLastActivityTime = new Map();
-    this.appHostName = config.appHostName;
+    this.routerDomain = config.routerDomain;
+    this.appName = config.appName;
     this.machineId = config.machineId;
     this.authManager = new AuthManager({
       authServerUrl: process.env.AUTH_SERVER_URL || 'https://v8-meme-api.verse8.io'
@@ -141,7 +145,7 @@ export class ContainerServer {
 
     this.portScanner.on('portAdded', (event: CandidatePort) => {
       console.log("🔓 포트가 열렸습니다!" + event.port);
-      const url = `https://${this.appHostName}/proxy/${this.machineId}/preview/?port=${event.port}`;
+      const url = `https://${this.appName}-${this.machineId}.${this.routerDomain}`;
       const message = JSON.stringify({
         data: {
           success: true,
@@ -159,7 +163,7 @@ export class ContainerServer {
 
     this.portScanner.on('portRemoved', (event: CandidatePort) => {
       console.log("🔓 포트가 닫혔습니다!" + event.port);
-      const url = `https://${this.appHostName}/proxy/${this.machineId}/preview/?port=${event.port}`;
+      const url = `https://${this.appName}-${this.machineId}.${this.routerDomain}`;
       const message = JSON.stringify({
         data: {
           success: true,
@@ -307,6 +311,12 @@ export class ContainerServer {
           headers.set('Access-Control-Allow-Origin', '*');
           headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
           headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+          // Allow embedding in iframes
+          headers.set('X-Frame-Options', 'ALLOWALL');
+          headers.set('Content-Security-Policy', "frame-ancestors *");
+          headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+          headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
 
           return new Response(proxyResponse.body, {
             status: proxyResponse.status,

--- a/src/server.ts
+++ b/src/server.ts
@@ -553,7 +553,7 @@ export class ContainerServer {
           if (!operation.command) {
             throw new Error("Command is required for spawn operation");
           }
-          return Promise.resolve(this.spawnProcess(operation.command, operation.args || [], ws));
+          return Promise.resolve(this.spawnProcess(operation.command, operation.args || [], ws, operation.options?.env));
         }
         case "input": {
           if (!(operation.pid && operation.data)) {
@@ -742,6 +742,7 @@ export class ContainerServer {
     command: string,
     args: string[],
     ws: ServerWebSocket<WebSocketData>,
+    env?: Record<string, string>,
   ): ContainerResponse<ProcessResponse> {
     // Use the Node.js PTY wrapper for terminal emulation
     // First try the container path, then fallback to local development path
@@ -771,7 +772,7 @@ export class ContainerServer {
     const childProcess = spawn('node', ptyArgs, {
       cwd: this.config.workdirName,
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, coep: this.config.coep },
+      env: { ...process.env, coep: this.config.coep, ...(env || {}) },
     });
 
     if (!(childProcess.stdin && childProcess.stdout && childProcess.pid)) {


### PR DESCRIPTION
This PR removes proxy codes for remote access since we decide to use separated router/proxy app with `fly-replay` features.

Instead of, it introduces local proxy features to expose Vite app from container.