### PR TITLE
Support local proxy to VITE Websockets

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,7 @@ export interface FileSystemWatcher {
 export interface ProxyData {
   targetUrl: string;
   targetSocket?: WebSocket;
+  headers?: Record<string, string>;
 }
 
 export interface DirectConnectionData {


### PR DESCRIPTION
We need to re-address it after choosing new `Sec-WebSocket-Protocol` for agent8 client.