### PR TITLE
Add dependency pre-caching with pnpm install in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -52,16 +52,15 @@ ENV PORT=3000 \
     NODE_ENV=development
 
 # Cache dependencies for all templates
-# RUN git clone --filter=blob:none --sparse https://github.com/planetarium/agent8-templates ./agent8-templates && \
-#     cd agent8-templates && \
-#     git sparse-checkout init --no-cone && \
-#     git sparse-checkout set */package.json
-
-RUN git clone https://github.com/planetarium/agent8-templates
+RUN git clone --filter=blob:none --sparse https://github.com/planetarium/agent8-templates ./agent8-templates && \
+    cd agent8-templates && \
+    git sparse-checkout init --no-cone && \
+    git sparse-checkout set */package.json
 
 WORKDIR /app/agent8-templates
 COPY pnpm-workspace.yaml ./pnpm-workspace.yaml
-RUN pnpm install
+ENV PNPM_HOME=/pnpm
+RUN pnpm install --prod
 
 WORKDIR /home/project
 

--- a/Containerfile
+++ b/Containerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
     make \
     g++ \
     build-essential \
+    git \
     && apt-get clean
 
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
@@ -49,6 +50,18 @@ ENV PORT=3000 \
     COEP=credentialless \
     FORWARD_PREVIEW_ERRORS=true \
     NODE_ENV=development
+
+# Cache dependencies for all templates
+# RUN git clone --filter=blob:none --sparse https://github.com/planetarium/agent8-templates ./agent8-templates && \
+#     cd agent8-templates && \
+#     git sparse-checkout init --no-cone && \
+#     git sparse-checkout set */package.json
+
+RUN git clone https://github.com/planetarium/agent8-templates
+
+WORKDIR /app/agent8-templates
+COPY pnpm-workspace.yaml ./pnpm-workspace.yaml
+RUN pnpm install
 
 WORKDIR /home/project
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  # Include all packages in direct subdirectories of the root
+  - '*'
+  # Exclude node_modules directories
+  - '!**/node_modules/**'


### PR DESCRIPTION
During the Docker image build, we ran pnpm install to cache template dependencies, expecting this to speed up the runtime pnpm install. However, the actual results were:

### With caching: Almost no downloads, but the added step took a long time. (9.5s)
<img width="1142" alt="cached" src="https://github.com/user-attachments/assets/904b0c76-992e-4415-8f5b-01763b3f8ec1" />

### Without caching: Downloading all dependencies took longer, but the added step was very fast. (9.3s)
<img width="1083" alt="nocache" src="https://github.com/user-attachments/assets/c3456b10-1848-4e95-87f6-92be65177348" />

### Overall
Total times were similar. On Mac (M1), both approaches performed comparably. On Windows (AMD64), the uncached run was about the same, but the cached run took over 50 seconds—slower overall. In all cases, most of the time was spent in the added phase.



