### PR TITLE
Add user for shell & use metadata

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get install -y \
     g++ \
     build-essential \
     git \
+    procps \
     && apt-get clean
 
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
@@ -85,6 +86,19 @@ WORKDIR /home/project
 COPY --from=template-builder /app/agent8-templates /app/agent8-templates
 COPY --from=template-builder /app/agent8-templates/node_modules ./node_modules
 COPY --from=template-builder /app/agent8-templates/pnpm-lock.yaml ./pnpm-lock.yaml
+
+COPY .zshrc /home/agent8/.zshrc
+
+# agent8 사용자 생성
+RUN groupadd -r -g 2000 agent8 && useradd -r -u 2000 -g agent8 -m agent8
+
+# 작업 디렉토리 생성 및 권한 설정
+RUN chown -R agent8:agent8 /home/project
+RUN chmod 777 /pnpm
+RUN chown -R agent8:agent8 /pnpm
+RUN chown -R agent8:agent8 /home/agent8
+# 다른 시스템 디렉토리 접근 제한
+RUN chmod 750 /proc
 
 EXPOSE 3000
 

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ function main() {
     appName: process.env.FLY_APP_NAME || "",
     machineId: process.env.FLY_MACHINE_ID || "",
     processGroup: process.env.FLY_PROCESS_GROUP || "app",
+    agentUid: Number.parseInt(process.env.AGENT_UID || "2000", 10),
   };
 
   console.info("container agent started with " + config.processGroup + " mode");

--- a/pty-wrapper/src/index.ts
+++ b/pty-wrapper/src/index.ts
@@ -46,7 +46,9 @@ const ptyProcess = pty.spawn(command, commandArgs, {
   cols,
   rows,
   cwd: process.cwd(),
-  env: process.env as { [key: string]: string }
+  env: process.env as { [key: string]: string },
+  uid: 2000,
+  gid: 2000
 });
 
 // Forward data from PTY to stdout

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { Dirent, Stats } from "node:fs";
-import { mkdir, readFile, readdir, rm, rmdir, stat, unlink, writeFile } from "node:fs/promises";
+import { chown, mkdir, readFile, readdir, rm, rmdir, stat, unlink, writeFile } from "node:fs/promises";
 import { join, normalize } from "node:path";
 import { PortScanner } from "./portScanner/portScanner.ts";
 import process from "node:process";
@@ -94,6 +94,7 @@ export class ContainerServer {
     appName: string;
     machineId: string;
     processGroup: string;
+    agentUid: number;
   };
   private authToken: string | undefined;
   private routerDomain: string;
@@ -108,6 +109,7 @@ export class ContainerServer {
   private readonly machineDestroyInterval = 300000; // 5 minutes
   private machinePool: MachinePool | null = null;
   private latestOpenPort: number | null = null;
+  private agentUid: number;
 
   constructor(config: {
     port: number;
@@ -118,6 +120,7 @@ export class ContainerServer {
     appName: string;
     machineId: string;
     processGroup: string;
+    agentUid: number;
   }) {
     this.config = config;
     this.processes = new Map();
@@ -130,6 +133,7 @@ export class ContainerServer {
     this.routerDomain = config.routerDomain;
     this.appName = config.appName;
     this.machineId = config.machineId;
+    this.agentUid = config.agentUid;
     this.authManager = new AuthManager({
       authServerUrl: process.env.AUTH_SERVER_URL || 'https://v8-meme-api.verse8.io'
     });
@@ -657,6 +661,7 @@ export class ContainerServer {
           await writeFile(fullPath, content, {
             encoding: (operation.options?.encoding as BufferEncoding) || "utf-8",
           });
+          await chown(fullPath, this.agentUid, this.agentUid);
           return { success: true, data: null };
         }
         case "rm": {
@@ -673,6 +678,7 @@ export class ContainerServer {
           await mkdir(fullPath, {
             recursive: operation.options?.recursive,
           });
+          await chown(fullPath, this.agentUid, this.agentUid);
           return { success: true, data: null };
         }
         case "stat": {
@@ -691,7 +697,8 @@ export class ContainerServer {
 
           const tree = JSON.parse(content) as FileSystemTree;
 
-          await mount(fullPath, tree);
+          await mount(fullPath, tree, this.agentUid);
+          await chown(fullPath, this.agentUid, this.agentUid);
           return { success: true, data: null };
         }
         default:
@@ -921,6 +928,9 @@ export class ContainerServer {
     // Use the Node.js PTY wrapper for terminal emulation
     // First try the container path, then fallback to local development path
     let ptyWrapperPath = '/app/pty-wrapper/dist/index.js';
+    const ALLOWED_ENV_VARS = [
+      '__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS', 'PNPM_STORE_DIR', 'PNPM_HOME', 'FORWARD_PREVIEW_ERRORS', 'TERM', 'PATH'
+    ];
 
     // Check if file exists using Node.js methods - more reliable across environments
     try {
@@ -943,10 +953,16 @@ export class ContainerServer {
       ...args
     ];
 
+    const mergedEnv = { ...process.env, ...(env || {}) };
+    const filteredEnv = Object.fromEntries(
+      ALLOWED_ENV_VARS
+        .map(key => [key, mergedEnv[key]])
+        .filter(([, v]) => v)
+    );
     const childProcess = spawn('node', ptyArgs, {
       cwd: this.config.workdirName,
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, coep: this.config.coep, ...(env || {}) },
+      env: filteredEnv,
       detached: true,
     });
 
@@ -1221,8 +1237,9 @@ export function ensureSafePath(workdir: string, userPath: string): string {
   );
 }
 
-async function mount(mountPath: string, tree: FileSystemTree) {
+async function mount(mountPath: string, tree: FileSystemTree, agentUid: number) {
   await mkdir(mountPath, { recursive: true });
+  await chown(mountPath, agentUid, agentUid);
 
   for (const [name, item] of Object.entries(tree)) {
     const fullPath = join(mountPath, name);
@@ -1230,8 +1247,9 @@ async function mount(mountPath: string, tree: FileSystemTree) {
     if ("file" in item) {
       await writeFile(fullPath, item.file.contents);
     } else if ("directory" in item) {
-      await mount(fullPath, item.directory);
+      await mount(fullPath, item.directory, agentUid);
     }
+    await chown(fullPath, agentUid, agentUid);
   }
 }
 


### PR DESCRIPTION
Related to #49, #51 

# Summary
This PR re-implements the previously rolled back user management functionality and enhances the scheduler synchronization logic.

# Changes
## User Management

- Re-added user switching functionality that was previously rolled back
- Enhanced machine allocation to record userId in metadata when machines are assigned

## Scheduler Synchronization Improvements

- Optimized sync logic for existing schedulers that are missing from the database
- Previous behavior: All schedulers were re-inserted into the database regardless of their state
- New behavior: Only machines without userId in metadata are inserted into the database
- Uses metadata inspection to determine which machines need database synchronization

