### PR TITLE
Add userID machine metadata

### DIFF
--- a/src/fly/client.ts
+++ b/src/fly/client.ts
@@ -121,29 +121,24 @@ export class FlyClient {
    * @param machineId - The ID of the machine to update
    * @param metadata - The metadata to set
    */
-  async updateMachineMetadata(machineId: string, metadata: Record<string, string>): Promise<void> {
+  async updateMachineMetadata(machineId: string, key: string, value: string): Promise<void> {
     try {
-      // 각 metadata key-value 쌍에 대해 개별 API 호출
-      await Promise.all(
-        Object.entries(metadata).map(async ([key, value]) => {
-          const res = await fetch(
-            `${this.config.baseUrl}/apps/${this.config.appName}/machines/${machineId}/metadata/${key}`,
-            {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${this.config.apiToken}`,
-                Accept: "application/json",
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({ value }),
-            }
-          );
-
-          if (!res.ok) {
-            throw new Error(`HTTP ${res.status} - ${res.statusText}`);
-          }
-        })
+      const res = await fetch(
+        `${this.config.baseUrl}/apps/${this.config.appName}/machines/${machineId}/metadata/${key}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.config.apiToken}`,
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ value }),
+        }
       );
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status} - ${res.statusText}`);
+      }
     } catch (e: unknown) {
       console.error("Fly API error (updateMachineMetadata):", e instanceof Error ? e.message : e);
       throw e;

--- a/src/fly/machinePool.ts
+++ b/src/fly/machinePool.ts
@@ -7,6 +7,7 @@ export class MachinePool {
   private readonly flyClient: FlyClient;
   private readonly defaultPoolSize: number;
   private readonly checkInterval: number;
+  private readonly metadataKey = "assigned_to" as const;
   private checkTimer: NodeJS.Timeout | null = null;
 
   constructor(
@@ -78,7 +79,7 @@ export class MachinePool {
         const metadataResults = await Promise.all(
           machinesToCheck.map(async (m) => {
             const metadata = await this.flyClient.getMachineMetadata(m.id);
-            return { machine: m, hasUserId: !!metadata?.assigned_to };
+            return { machine: m, hasUserId: !!metadata?.[this.metadataKey] };
           })
         );
 
@@ -220,7 +221,7 @@ export class MachinePool {
 
       // Set metadata after machine creation
       try {
-        await this.flyClient.updateMachineMetadata(machine.id, { assigned_to: userId });
+        await this.flyClient.updateMachineMetadata(machine.id, this.metadataKey, userId);
       } catch (error) {
         console.error('Error setting machine metadata:', error);
         // Metadata 설정 실패는 치명적이지 않으므로 계속 진행
@@ -282,7 +283,7 @@ export class MachinePool {
 
         // Update machine metadata with userId
         try {
-          await this.flyClient.updateMachineMetadata(machineId, { assigned_to: userId });
+          await this.flyClient.updateMachineMetadata(machineId, this.metadataKey, userId);
         } catch (error) {
           console.error('Error updating machine metadata:', error);
           // Metadata update 실패는 치명적이지 않으므로 계속 진행


### PR DESCRIPTION
# Summary
This PR enhances the scheduler synchronization logic.

# Changes
## Scheduler Synchronization Improvements

- Optimized sync logic for existing schedulers that are missing from the database
- Previous behavior: All schedulers were re-inserted into the database regardless of their state
- New behavior: Only machines without userId in metadata are inserted into the database
- Uses metadata inspection to determine which machines need database synchronization