### PR TITLE
usePolling to care missing events

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1079,6 +1079,7 @@ export class ContainerServer {
     const watcher = chokidar.watch(this.config.workdirName, {
       persistent: true,
       ignoreInitial: options.ignoreInitial,
+      usePolling: true,
       ignored: (path) => {
         if (path === this.config.workdirName) {
           return false;


### PR DESCRIPTION
See also: https://github.com/planetarium/agent8/issues/237

As title suggests, it forces to use polling instead of inotify events, to address event missing issue.
