### PR TITLE
Handle SIGINT properly

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -9,9 +9,18 @@ send_osc654() {
 # detect first run
 JSH_EMULATOR_FIRST_RUN=1
 
+# prevent duplicate OSC messages
+JSH_OSC_SENT=0
+
 # after command, before prompt
 precmd_function() {
   local EXIT_CODE=$?
+  
+  # if TRAPINT already sent OSC, skip this execution
+  if [[ $JSH_OSC_SENT -eq 1 ]]; then
+    JSH_OSC_SENT=0  # reset flag
+    return
+  fi
 
   # when first run, set flag to 0 and do nothing
   if [[ $JSH_EMULATOR_FIRST_RUN -eq 1 ]]; then
@@ -21,6 +30,19 @@ precmd_function() {
 
   send_osc654 "exit=$EXIT_CODE:0"
   send_osc654 "prompt"
+}
+
+# Handle SIGINT (Ctrl+C)
+TRAPINT() {
+  # send OSC messages for interrupt
+  send_osc654 "exit=130:0"
+  send_osc654 "prompt"
+  
+  # set flag to prevent duplicate execution in precmd
+  JSH_OSC_SENT=1
+  
+  # return proper SIGINT exit code
+  return $(( 128 + 2 ))
 }
 
 # register hook


### PR DESCRIPTION
As title suggests, this pr fixes SIGINT handling, by adding `TRAPINT` handler to send osc code properly. (see also: https://superuser.com/a/1156023)